### PR TITLE
length-factors: adding a target precentage for read coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ After building:
 ```bash
 pair up potential reverse complement reads
 Usage:
-  sniff [OPTION...] positional parameters
+  sniff [OPTION...] <reads>
 
  general options:
   -h, --help         print help
@@ -22,17 +22,21 @@ Usage:
   -t, --threads arg  number of threads to use (default: 1)
 
  heuristic options:
-  -p, --percent arg  maximum allowed difference in length as % of shorter
-                     read's length (default: 0.01)
+  -a, --alpha-percent arg  maximum allowed difference in length as % of 
+                           shorter read's length (default: 0.01)
+  -b, --beta-percent arg   minimum required coverage on each read (default: 
+                           0.95)
 
  input options:
+      --input arg  input fasta/fastq file
 
  mapping options:
   -k, --kmer-length arg    kmer length used in mapping (default: 15)
   -w, --window-length arg  window length used in mapping (default: 5)
   -c, --chain arg          minimum chain length (in kmers) (default: 4)
-  -g, --gap arg            maximum gap between minimizers when chaining
+  -g, --gap arg            maximum gap between minimizers when chaining 
                            (default: 500)
+
 ```
 
 ## Dependencies

--- a/eval/run_sniff.py
+++ b/eval/run_sniff.py
@@ -39,8 +39,8 @@ DF_COLS = [
 
 DEFAULT_ARGS = SniffArgs(
     threads=32,
-    alpha_percent=0.01,
-    beta_percent=0.95,
+    alpha_percent=0.1,
+    beta_percent=0.98,
     kmer_length=15,
     window_length=5,
     chain=4,

--- a/eval/run_sniff.py
+++ b/eval/run_sniff.py
@@ -11,7 +11,8 @@ from pydantic import BaseModel
 
 class SniffArgs(BaseModel):
     threads: int
-    percent: float
+    alpha_percent: float
+    beta_percent: float
     kmer_length: int
     window_length: int
     chain: int
@@ -22,8 +23,6 @@ class RunInfo(BaseModel):
     runtime_s: float
     peak_memory_gib: float
 
-
-SNIFF_TMP_PAIRS = '/tmp/sniff-pairs.csv'
 
 DF_COLS = [
     'threads',
@@ -40,7 +39,8 @@ DF_COLS = [
 
 DEFAULT_ARGS = SniffArgs(
     threads=32,
-    percent=0.01,
+    alpha_percent=0.01,
+    beta_percent=0.95,
     kmer_length=15,
     window_length=5,
     chain=4,
@@ -73,18 +73,18 @@ def run_sniff(
         sniff_args: SniffArgs,
         reads_path: str | pathlib.Path) -> pl.DataFrame:
 
-    with open(SNIFF_TMP_PAIRS, 'w+', encoding='utf-8') as pairs_dst:
-        with Popen(create_sniff_spawn_list(sniff_path, sniff_args, reads_path),
-                   stdout=pairs_dst) as proc:
-            peak_memory = 0
-            time_start = time_end = perf_counter()
+    with Popen(create_sniff_spawn_list(
+        sniff_path, sniff_args, reads_path)
+    ) as proc:
+        peak_memory = 0
+        time_start = time_end = perf_counter()
 
-            while proc.poll() is None:
-                curr_mem = proc.memory_info().rss
-                time_end = perf_counter()
+        while proc.poll() is None:
+            curr_mem = proc.memory_info().rss
+            time_end = perf_counter()
 
-                if curr_mem is not None and curr_mem > peak_memory:
-                    peak_memory = curr_mem
+            if curr_mem is not None and curr_mem > peak_memory:
+                peak_memory = curr_mem
 
     return pl.DataFrame(sniff_args.dict() | RunInfo(
         runtime_s=int(time_end-time_start),
@@ -125,6 +125,3 @@ if __name__ == "__main__":
             print(df_run_info.write_csv(), file=f)
     else:
         print(df_run_info, file=sys.stderr)
-
-    with open(SNIFF_TMP_PAIRS, 'r', encoding='utf-8') as rc_pairs:
-        print(rc_pairs.read())

--- a/include/sniff/config.h
+++ b/include/sniff/config.h
@@ -6,7 +6,8 @@
 namespace sniff {
 
 struct Config {
-  double p;
+  double alpha_p;
+  double beta_p;
   MapConfig map_cfg;
   MinimizeConfig minimize_cfg;
 };

--- a/src/algo.cc
+++ b/src/algo.cc
@@ -165,9 +165,9 @@ static auto IsSpanningOverlap(
 
   if (auto const& detail_ovlp = ovlps.front();
       !(1. * (detail_ovlp.query_end - detail_ovlp.query_start) >
-            0.875 * query_reads[src_ovlp.query_id]->inflated_len &&
+            cfg.beta_p * query_reads[src_ovlp.query_id]->inflated_len &&
         1. * (detail_ovlp.target_end - detail_ovlp.target_start) >
-            0.875 * query_reads[src_ovlp.target_id]->inflated_len)) {
+            cfg.beta_p * query_reads[src_ovlp.target_id]->inflated_len)) {
     return false;
   }
 
@@ -224,7 +224,7 @@ static auto MapSketchToIndex(
     std::span<std::unique_ptr<biosoup::NucleicAcid> const> query_reads,
     Sketch const& sketch, KMerLocIndex const& index, double threshold)
     -> std::optional<Overlap> {
-  auto const min_short_long_ratio = 1.0 - cfg.p;
+  auto const min_short_long_ratio = 1.0 - cfg.alpha_p;
   auto read_matches = std::vector<Match>();
   auto const try_match =
       [query_reads, min_short_long_ratio, &query_sketch = sketch, &read_matches,
@@ -350,7 +350,6 @@ auto FindReverseComplementPairs(
     Config const& cfg, std::vector<std::unique_ptr<biosoup::NucleicAcid>> reads)
     -> std::vector<RcPair> {
   auto opt_ovlps = std::vector<std::optional<Overlap>>(reads.size());
-
   auto timer = biosoup::Timer{};
   timer.Start();
 

--- a/src/config.cc
+++ b/src/config.cc
@@ -1,0 +1,1 @@
+#include "sniff/config.h"

--- a/src/main.cc
+++ b/src/main.cc
@@ -34,9 +34,12 @@ int main(int argc, char** argv) {
       ("t,threads", "number of threads to use",
         cxxopts::value<std::uint32_t>()->default_value("1"));
     options.add_options("heuristic")
-      ("p,percent",
+      ("a,alpha-percent",
         "maximum allowed difference in length as % of shorter read's length",
-        cxxopts::value<double>()->default_value("0.01"));
+        cxxopts::value<double>()->default_value("0.01"))
+      ("b,beta-percent",
+        "minimum required coverage on each read",
+        cxxopts::value<double>()->default_value("0.95"));
     options.add_options("mapping")
       ("k,kmer-length", "kmer length used in mapping",
         cxxopts::value<std::uint32_t>()->default_value("15"))
@@ -81,7 +84,8 @@ int main(int argc, char** argv) {
 
     task_arena.execute([&] {
       auto const cfg = sniff::Config{
-          .p = result["percent"].as<double>(),
+          .alpha_p = result["alpha-percent"].as<double>(),
+          .beta_p = result["beta-percent"].as<double>(),
           .map_cfg =
               sniff::MapConfig{
                   .min_chain_length = result["chain"].as<std::uint32_t>(),
@@ -96,7 +100,7 @@ int main(int argc, char** argv) {
           "[sniff]\n"
           "\tp: {};\n"
           "\tk: {}; w: {}; chain: {}; gap: {};\n",
-          cfg.p,
+          cfg.alpha_p,
           cfg.minimize_cfg.kmer_len, cfg.minimize_cfg.window_len,
           cfg.map_cfg.min_chain_length, cfg.map_cfg.max_chain_gap_length);
       /* clang-format on */


### PR DESCRIPTION
# Context

Sniff is read to read mapping tool designed to pair up reverse complement reads. For evaluating output correctness all reads are mapped to the reference genome using [minimap2](https://github.com/lh3/minimap2). For predicted pairs we look how much do they overlap on the reference compared to the union of their reference coverage. See graphic below.

![Slide 4_3 - 1gamma](https://github.com/tbrekalo/sniff/assets/32259102/cd2a7336-267e-467b-bf6a-61aaaa144b7a)

If we exclude the reference from the graphic and just look at the reads; we can define a &#914; factor. `A-beta = AB overlap / A length`, `B-beta = AB  overlap / B length`. The higher the beta factors for reads in the pair; the higher the likelihood they will have a strong overlap on the reference.

# Evaluation

## Beta factor impact
- on the far left it is the master version of sniff which doesn't take in account beta factors
- in the middle is modified version of sniff taking into account beta factors
  - `alpha-percent = 0.01; beta-percent = 0.95` on the graph
- on the far right is the ground truth data obtained with ONT duplex tools

![image](https://github.com/tbrekalo/sniff/assets/32259102/1c289fe5-3994-47ab-ac4c-968b271bbc76)

## Beta and alpha impact

![image](https://github.com/tbrekalo/sniff/assets/32259102/4877ad12-b5fb-435e-b87c-80ab1306fa3a)


After plotting the correlation between read length ratio (`min(query_length, target_length) / max(query_length, target_length)`) and `gamma` (see graphic above)  we concluded that the `alpha` parameter was too strict. Relaxing it to `0.10` and increasing `beta` to `0.98` gave much better results. 

![image](https://github.com/tbrekalo/sniff/assets/32259102/f42b7dac-983d-4b46-8415-402134bebeaf)
