### PR TITLE
Overhang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ FetchContent_Declare(
 
 FetchContent_MakeAvailable(bioparser biosoup cxxopts fmt unordered_dense)
 
-
 find_package(TBB)
 add_library(
   sniff_lib
@@ -74,7 +73,8 @@ if(SNIFF_BUILD_ASAN)
   target_compile_options(
     sniff PRIVATE $<$<CONFIG:Debug,RelWithDebInfo>:-fsanitize=address>
                   $<$<CONFIG:Debug,RelWithDebInfo>:-fno-omit-frame-pointer>)
-  target_link_options(sniff PRIVATE $<$<CONFIG:Debug,RelWithDebInfo>:-fsanitize=address>)
+  target_link_options(sniff PRIVATE
+                      $<$<CONFIG:Debug,RelWithDebInfo>:-fsanitize=address>)
 endif()
 
 set_target_properties(sniff PROPERTIES VERSION ${sniff_VERSION}

--- a/src/algo.cc
+++ b/src/algo.cc
@@ -11,7 +11,6 @@
 #include "ankerl/unordered_dense.h"
 #include "biosoup/nucleic_acid.hpp"
 #include "biosoup/timer.hpp"
-#include "edlib.h"
 #include "fmt/core.h"
 #include "tbb/tbb.h"
 
@@ -227,17 +226,6 @@ static auto OverlapScore(
          (query_strenght + target_strenght) / 2.;
 }
 
-static auto CalcNormEditDist(std::string const& query_str,
-                             std::string const& target_str) {
-  auto const edlib_res = edlibAlign(
-      query_str.data(), query_str.size(), target_str.data(), target_str.size(),
-      edlibNewAlignConfig(-1, EDLIB_MODE_NW, EDLIB_TASK_DISTANCE, nullptr, 0));
-  auto const dst = edlib_res.editDistance;
-  edlibFreeAlignResult(edlib_res);
-
-  return static_cast<double>(dst) /
-         std::max(query_str.size(), target_str.size());
-}
 
 static auto MakeScoredOverlap(
     sniff::Config const& cfg,

--- a/src/algo.cc
+++ b/src/algo.cc
@@ -22,11 +22,11 @@
 
 static constexpr auto kIndexSize = 1U << 30U;
 
-static constexpr auto kCoefs =
-    std::tuple{11.57313245, -7.62558864,  -3.94786743,
-               21.98504372, -10.46454548, -11.52078862};
+static constexpr auto kCoefs = std::tuple{
+    9.42746909, -6.64572836, -2.78147289, 16.18407094, -7.31525403, -8.86853227,
+};
 
-static constexpr auto kIntercept = -31.88110504;
+static constexpr auto kIntercept = -23.47084474;
 
 template <class... Args>
 requires((std::is_integral_v<Args> || std::is_floating_point_v<Args>) ||


### PR DESCRIPTION
# Description 

The goal of this PR is to enhance overlap filtering using logistic regression. 

## Methods 

Logistic regression was trained on a subset of overlaps found by sniff. Overlaps which have intersection over union on reference higher than 0.90, map to the reference with different strands and are found in ONT duplex tools pairs are marked as target positives. The constructed subset contained 5000 pairs. The 70/30 split used for training and validation.  The model achieved 85.20% accuracy on the test data set. The features used for training were:

- `query_score`: percentage of query read covered by the overlap
- `query_lhs_overhang`: percentage of query bases forming an overhang on left hand side
- `query_rhs_overhang`: percentage of query bases forming an overhang on the right hand side 
- `target_score`: percentage of target read covered by the overlap
- `target_lhs_overhang`: percentage of target bases forming an overhang on left hand side
- `target_rhs_overhang`: percentage of target bases forming an overhang on the right hand side 

### Report:

|           | Precision | Recall | F1-Score | Support |
|---------- |---------- |------- |--------- |-------- |
|     0     |    0.82   |  0.81  |   0.81   |   599   |
|     1     |    0.87   |  0.88  |   0.88   |   901   |
| **Accuracy** |           |        |   0.85   |  1500   |
| **Macro Avg** |   0.85   |  0.84  |   0.85   |  1500   |
| **Weighted Avg** | 0.85   |  0.85  |   0.85   |  1500   |

![image](https://github.com/tbrekalo/sniff/assets/32259102/dc7e5f5c-bdef-4c1a-977f-a50173a61982)

![image](https://github.com/tbrekalo/sniff/assets/32259102/9853a723-eec2-4f20-8e4b-0ca7ac2863fb)

### Impact on `sniff` performance

#### Precision 

In the previous section we had a bit of a *'different/stronger'* definition of a true positive. There we said that a pair of reads in an overlap is a true positive if it had a sufficient overlap on of reads on the reference, reads are overlapping with different strands and the pair is found in ONT dataset. Here we omit the *`found in ONT duplex tools data-set..`* part since we are evaluating that data-set also.

| data-set       | precision | n-samples |
|----------------|-----------|-----------|
| sniff-master   | 0.745068  | 143152    |
| sniff-overhang | 0.756777  | 89942     |
| ont-duplex     | 0.708707  | 10704     |


![image](https://github.com/tbrekalo/sniff/assets/32259102/686fd377-95c8-4d9e-a969-ed0b1f85a519)

#### Runtime

| branch   |   threads |   alpha |   beta |   window_length |   kmer_length |   runtime_s |   peak_memory_gib |
|:---------|----------:|--------:|-------:|----------------:|--------------:|------------:|------------------:|
| master   |        32 |     0.1 |    0.9 |               5 |            15 |         328 |           7.47564 |
| overhang |        32 |     0.1 |    0.9 |               5 |            15 |         368 |           7.48126 |

![image](https://github.com/tbrekalo/sniff/assets/32259102/a5bbf8fd-2aac-43a6-ae38-e84a289d0b65)
